### PR TITLE
[FEATURE] Add scheme option for url type validation

### DIFF
--- a/addon/format.js
+++ b/addon/format.js
@@ -21,6 +21,7 @@ const { canInvoke } = Ember;
  * @param {Regex} options.regex The regular expression to test against
  * @param {Boolean} options.allowNonTld If true, the predefined regular expression `email` allows non top-level domains
  * @param {Number} options.minTldLength The min length of the top-level domain on the predefined `email` regular expression
+ * @param {Any} options.scheme Adds scheme requirements on the predefined regular expression `url`
  * @param {Object} model
  * @param {String} attribute
  */
@@ -58,6 +59,11 @@ export default function validateFormat(value, options, model, attribute) {
       regexTest = formatEmailRegex(options);
     }
     Object.assign({}, options, { regex: regexTest });
+  } else if (type === 'url') {
+    if (regexTest === regularExpressions.url) {
+      regexTest = formatUrlRegex(options);
+    }
+    Object.assign({}, options, { regex: regexTest });
   }
 
   if (
@@ -93,4 +99,17 @@ function formatEmailRegex(options) {
   }
 
   return new RegExp(source, 'i');
+}
+
+function formatUrlRegex(options) {
+  let { source } = regularExpressions.url;
+  let { scheme } = options;
+
+  if (scheme === true) {
+    source = `^([a-zA-Z0-9-+&.]+)://${source}`;
+  } else if (scheme instanceof Array) {
+    source = `^(${scheme.join('|')}){1}://${source}`;
+  }
+
+  return new RegExp(source);
 }

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -173,6 +173,67 @@ test('url', function (assert) {
   assert.true(processResult(result));
 });
 
+test('url + scheme as true', function (assert) {
+  assert.expect(5);
+
+  options = {
+    type: 'url',
+    scheme: true,
+  };
+
+  options = cloneOptions(options);
+
+  result = validate('offirgolan', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('offir.golan', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('ht_tp://offir.golan', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('http://www.offirgolan.com', options);
+  assert.true(processResult(result));
+
+  result = validate('a+B.c-d&e://www.offirgolan.com', options);
+  assert.true(processResult(result));
+});
+
+test('url + scheme as array', function (assert) {
+  assert.expect(8);
+
+  options = {
+    type: 'url',
+    scheme: ['https', 'http'],
+  };
+
+  options = cloneOptions(options);
+
+  result = validate('offirgolan', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('offir.golan', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('htt://offirgolan.com', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('httpextra://www.offirgolan.com', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('extrahttp://www.offirgolan.com', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('httphttps://www.offirgolan.com', options);
+  assert.strictEqual(processResult(result), 'This field must be a valid url');
+
+  result = validate('http://www.offirgolan.com', options);
+  assert.true(processResult(result));
+
+  result = validate('https://www.offirgolan.com', options);
+  assert.true(processResult(result));
+});
+
 test('inverse - with type', function (assert) {
   assert.expect(2);
 


### PR DESCRIPTION
## API Changes

- Added passive `scheme` option to augment `type: 'url'` validation
- Added unit tests 

## Notes

- [List of schemes on Wikipedia](https://en.wikipedia.org/wiki/List_of_URI_schemes)