### PR TITLE
fix(presence): fix doc and add option to allow empty string

### DIFF
--- a/addon/presence.js
+++ b/addon/presence.js
@@ -14,14 +14,19 @@ import unwrapProxy from 'ember-validators/utils/unwrap-proxy';
  * @param {Object} options
  * @param {Boolean} options.presence If true validates that the given value is not empty,
  *                                   if false, validates that the given value is empty.
- * @param {Boolean} options.ignoreBlank If true, treats an empty or whitespace string as not present
+ * @param {Boolean} options.ignoreBlank If true, treats a whitespace string as not present
+ * @param {Boolean} options.allowEmpty If true, treats an empty string as present
  * @param {Object} model
  * @param {String} attribute
  */
 export default function validatePresence(value, options, model, attribute) {
-  let { presence, ignoreBlank } = options;
+  let { presence, ignoreBlank, allowEmpty } = options;
   let v = unwrapProxy(value);
   let _isPresent = ignoreBlank ? isPresent(v) : !isEmpty(v);
+
+  if (!_isPresent && allowEmpty && v === '') {
+    _isPresent = true;
+  }
 
   assert(
     `[validator:presence] [${attribute}] option 'presence' is required`,

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -16,6 +16,24 @@ test('presence - value present', function (assert) {
   assert.true(processResult(result));
 });
 
+test('presence - value empty', function (assert) {
+  assert.expect(1);
+
+  options = { presence: true };
+
+  result = validate('', cloneOptions(options));
+  assert.strictEqual(processResult(result), "This field can't be blank");
+});
+
+test('presence with allowEmpty - value empty', function (assert) {
+  assert.expect(1);
+
+  options = { presence: true, allowEmpty: true };
+
+  result = validate('', cloneOptions(options));
+  assert.true(processResult(result));
+});
+
 test('presence - value blank', function (assert) {
   assert.expect(1);
 


### PR DESCRIPTION
# Problem

The current ignoreBlank option said it treats an empty string as not present.
But as you can see in the test, this exact use case throw an error.

# Current solution

- Add test about the failing use case
- Add a new `allowEmpty` option to handle that specific use case and not break the current integration
- Update the JSDoc accordingly
