### PR TITLE
Drop support for Ember.js versions below 4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.16
-          - ember-lts-3.20
-          - ember-lts-3.24
-          - ember-lts-3.28
           - ember-release
           - ember-beta
           - ember-canary

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 
 A collection of EmberJS validators
 
+## Compatibility
+
+- Ember.js v4.8 or above
+
+## Installation
 
 ```shell
 ember install ember-validators

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,46 +7,6 @@ module.exports = async function () {
   return {
     scenarios: [
       {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.0',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "webpack": "^5.67.0",
     "yuidoc-ember-theme": "1.3.0"
   },
+  "peerDependencies": {
+    "ember-source": ">= 4.8.0"
+  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },


### PR DESCRIPTION
This simplifies CI setup and support for Embroider/Vite moving forward.

Currently Ember.js v6.3 is the latest version, so it's still two old major versions.

As addon is pretty simple, there is high chance it would work even with older versions if needed.